### PR TITLE
Fix composer hook failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,9 +105,9 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "cp -r 'hooks/' '.git/hooks/'",
-            "php -r \"copy('hooks/pre-commit', '.git/hooks/pre-commit');\"",
-            "php -r \"chmod('.git/hooks/pre-commit', 0777);\""
+            "bash -c '[ -d hooks ] && cp -r hooks/. .git/hooks/ || true'",
+            "php -r \"if (file_exists('hooks/pre-commit')) copy('hooks/pre-commit', '.git/hooks/pre-commit');\"",
+            "php -r \"if (file_exists('hooks/pre-commit')) chmod('.git/hooks/pre-commit', 0777);\""
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force",


### PR DESCRIPTION
## Summary
- avoid failing Docker builds when `hooks` directory missing by wrapping `post-install-cmd` scripts with existence checks

## Testing
- `php -l app/Console/Kernel.php`
- `composer run test` *(fails: `Script "test" is not defined in this package`)*


------
https://chatgpt.com/codex/tasks/task_e_685f3ccd103c8325b40618b30d5214ad