### PR TITLE
Fix missing InstanceSettings record

### DIFF
--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -85,7 +85,17 @@ class InstanceSettings extends Model
 
     public static function get()
     {
-        return InstanceSettings::findOrFail(0);
+        return InstanceSettings::firstOrCreate(
+            ['id' => 0],
+            [
+                'is_registration_enabled' => true,
+                'smtp_enabled' => true,
+                'smtp_host' => 'coolify-mail',
+                'smtp_port' => 1025,
+                'smtp_from_address' => 'hi@localhost.com',
+                'smtp_from_name' => 'Coolify',
+            ]
+        );
     }
 
     // public function getRecipients($notification)

--- a/database/seeders/InstanceSettingsSeeder.php
+++ b/database/seeders/InstanceSettingsSeeder.php
@@ -13,15 +13,17 @@ class InstanceSettingsSeeder extends Seeder
      */
     public function run(): void
     {
-        InstanceSettings::create([
-            'id' => 0,
-            'is_registration_enabled' => true,
-            'smtp_enabled' => true,
-            'smtp_host' => 'coolify-mail',
-            'smtp_port' => 1025,
-            'smtp_from_address' => 'hi@localhost.com',
-            'smtp_from_name' => 'Coolify',
-        ]);
+        InstanceSettings::updateOrCreate(
+            ['id' => 0],
+            [
+                'is_registration_enabled' => true,
+                'smtp_enabled' => true,
+                'smtp_host' => 'coolify-mail',
+                'smtp_port' => 1025,
+                'smtp_from_address' => 'hi@localhost.com',
+                'smtp_from_name' => 'Coolify',
+            ]
+        );
         try {
             $ipv4 = Process::run('curl -4s https://ifconfig.io')->output();
             $ipv4 = trim($ipv4);


### PR DESCRIPTION
## Summary
- handle missing instance settings by creating default record
- prevent seeder duplicate errors with `updateOrCreate`

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6860dc6a81f4832595848d1e94c6689a