### PR TITLE
Fix FastCGI include path

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -49,7 +49,10 @@ http {
             fastcgi_pass   127.0.0.1:9000;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            include /etc/nginx/fastcgi_params;
+            # Include the bundled FastCGI parameters instead of relying on
+            # the system-wide file which might not exist in minimal
+            # containers such as Alpine.
+            include fastcgi_params;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix Nginx config to include bundled `fastcgi_params`

## Testing
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_6860f95ff474832595417c429168a410